### PR TITLE
Add number_extra() for numeric inputs in reactable

### DIFF
--- a/R/inputs.R
+++ b/R/inputs.R
@@ -115,6 +115,33 @@ date_extra <- function(id, key = NULL, ...) {
   )
 }
 
+#' Numeric input for reactable column cell
+#'
+#' @param id id of the input
+#' @param key alternative unique id for server side processing
+#' @param ... parameters of numeric input, only `class` is supported for now
+#'
+#' @examples
+#' reactable::colDef(cell = number_extra("date", class = "table-number"))
+#'
+#' @export
+number_extra <- function(id, key = NULL, ...) {
+  key <- define_key(key)
+  reactable::JS(
+    htmltools::doRenderTags(
+      htmltools::htmlTemplate(
+        text_ = "function(cellInfo) {
+              return React.createElement(numberExtras,
+              {id: '{{id}}', value: cellInfo.value, uuid: {{key}},
+               column: cellInfo.column.id {{args}}}, cellInfo.id)
+      }",
+      id = id,
+      key = key,
+      args = args_js(...))
+    )
+  )
+}
+
 #' Select input for reactable column cell
 #'
 #' @param id id of the select input

--- a/inst/assets/js/reactable-extras.js
+++ b/inst/assets/js/reactable-extras.js
@@ -25,6 +25,17 @@ function dateExtras ({ id, value, uuid, column, className, children }) {
   )
 };
 
+function numberExtras ({ id, value, uuid, column, className, children }) {
+  const onChange = event => {
+    Shiny.setInputValue(id, { row: uuid, value: event.target.value, column: column }, { priority: 'event' })
+  }
+
+  return React.createElement(
+    'input',
+    { type: 'number', key: uuid, defaultValue: value, onChange, className }
+  )
+};
+
 function dropdownExtras ({ id, value, uuid, column, choices, className, children }) {
   const onChange = event => {
     Shiny.setInputValue(id, { row: uuid, value: event.target.value, column: column }, { priority: 'event' })


### PR DESCRIPTION
*Have you read the [Contributing Guidelines](https://github.com/Appsilon/.github/blob/main/CONTRIBUTING.md)?*

Issue #25 

## Changes description

1. `number_extra` function and its js wrapper `numberExtras` were added

## How to test

Run this example and play with the numbers

```
library(shiny)
library(reactable)
library(reactable.extras)

string_list <- function(values) {
  paste0(
    "{", paste0(names(values), " : ", unlist(values), collapse = ", "), "}"
  )}

ui <- fluidPage(
  reactable_extras_dependency(),
  reactableOutput("react"),
  textOutput("number_text"),
  textOutput("text")
)

server <- function(input, output, session) {
  output$react <- renderReactable({
    tibble::tibble(
      name = c("Portfolio 1", "Portfolio 2", "Portfolio 3"),
      expected_return = c(0.0687, 0.060, 0.050) * 100,
      expected_volatility = c(0.1575, 0.140, 0.120) * 100
    ) |>
      reactable(
        columns = list(
          name = colDef(cell = text_extra("text")),
          expected_return = colDef(cell = number_extra("number", class = "number-extra"))
        )
      )
  })
  output$text <- renderText({
    req(input$text)
    values <- input$text
    paste0(
      "Text: ",
      string_list(values)
    )
  })

  output$number_text <- renderText({
    req(input$number)
    values <- input$number
    paste0(
      "Text: ",
      string_list(values)
    )
  })
}

shinyApp(ui, server)
```
