### PR TITLE
feat: Sticks input changes on tables with pagination

### DIFF
--- a/inst/assets/js/reactable-extras.js
+++ b/inst/assets/js/reactable-extras.js
@@ -1,3 +1,14 @@
+memory = {};
+
+function tryFromMemory (id, uuid, column, value) {
+  let mem_value = memory[[id, uuid, column]];
+  return mem_value ? mem_value : value;
+}
+
+function updateMemory (id, uuid, column, value) {
+  memory[[id, uuid, column]] = value;
+}
+
 function ButtonExtras ({ id, label, uuid, column, className, children }) {
   const onClick = event => {
     Shiny.setInputValue(id, { row: uuid, column: column}, { priority: 'event' })
@@ -7,7 +18,11 @@ function ButtonExtras ({ id, label, uuid, column, className, children }) {
 };
 
 function checkboxExtras ({ id, value, uuid, column, className, children }) {
+
+  value = tryFromMemory(id, uuid, column, value);
+
   const onChange = event => {
+    updateMemory(id, uuid, column, event.target.checked);
     Shiny.setInputValue(id, { row: uuid, value: event.target.checked, column: column }, { priority: 'event' })
   }
 
@@ -15,7 +30,11 @@ function checkboxExtras ({ id, value, uuid, column, className, children }) {
 };
 
 function dateExtras ({ id, value, uuid, column, className, children }) {
+
+  value = tryFromMemory(id, uuid, column, value);
+
   const onChange = event => {
+    updateMemory(id, uuid, column, event.target.value);
     Shiny.setInputValue(id, { row: uuid, value: event.target.value, column: column }, { priority: 'event' })
   }
 
@@ -26,7 +45,11 @@ function dateExtras ({ id, value, uuid, column, className, children }) {
 };
 
 function dropdownExtras ({ id, value, uuid, column, choices, className, children }) {
+
+  value = tryFromMemory(id, uuid, column, value);
+
   const onChange = event => {
+    updateMemory(id, uuid, column, event.target.value);
     Shiny.setInputValue(id, { row: uuid, value: event.target.value, column: column }, { priority: 'event' })
   }
 
@@ -42,7 +65,11 @@ function dropdownExtras ({ id, value, uuid, column, choices, className, children
 };
 
 function textExtras ({ id, value, uuid, column, page, className, children }) {
+
+  value = tryFromMemory(id, uuid, column, value);
+
   const onInput = event => {
+    updateMemory(id, uuid, column, event.target.value);
     Shiny.setInputValue(id, { row: uuid, value: event.target.value, column: column }, { priority: 'event' })
   }
 


### PR DESCRIPTION
Fixes the issue with state of inputs for tables with pagination as mentioned in the `README.md`.

## Changes description

- Adds a shared object on the client that keeps track of the input value changes on the reactable. This eliminates the need for serverside state management for input. 

This was a very simple edit and adds little to no overhead when rendering tables as it only records changes.