### PR TITLE
fix: make dropdown work with a singular choice

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Type: Package
 Package: reactable.extras
 Title: Extra Features for 'reactable' Package
-Version: 0.2.0.9000
+Version: 0.2.0.9001
 Authors@R:
   c(
     person("Recle", "Vibal", role = c("aut", "cre"), email = "opensource+recle@appsilon.com"),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,7 @@
 # reactable.extras (development)
 
 - Fix server-side processing example.
+- Dropdown now work with a singular choice.
 
 # reactable.extras 0.2.0
 

--- a/R/inputs.R
+++ b/R/inputs.R
@@ -129,7 +129,7 @@ build_dropdown_extra_choices <- function(choices) {
   if (length(choices) == 0) {
     choices_js <- ""
   } else {
-    choices_js <- paste0(", choices: ", rjson::toJSON(choices))
+    choices_js <- paste0(", choices: ", rjson::toJSON(as.list(choices)))
   }
 
   return(choices_js)

--- a/tests/testthat/test-inputs.R
+++ b/tests/testthat/test-inputs.R
@@ -34,6 +34,12 @@ test_that("`dropdown_extra` sets choices to blank when length is 0", {
   expect_equal(choices, "")
 })
 
+test_that("`dropdown_extra` serializes a single value as an array", {
+  choices <- build_dropdown_extra_choices("a")
+
+  expect_equal(choices, ', choices: ["a"]')
+})
+
 test_that("`dropdown_extra` sets choices correctly", {
   choices <- build_dropdown_extra_choices(letters[1:3])
 


### PR DESCRIPTION
Issue #60

## Description
Prior to this change a singular value wasn't serialized as an array. This lead to JS errors when trying to set options.

## Definition of Done
- [x] The change is thoroughly documented.
- [ ] The CI passes (`R CMD check`, linter, unit tests, spelling).
- [x] Any generated files have been updated (e.g. `.Rd` files with `roxygen2::roxygenise()`)
