### PR TITLE
Docs/deprecate serverside module

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -40,4 +40,4 @@ Encoding: UTF-8
 Language: en-US
 LazyData: true
 Roxygen: list(markdown = TRUE)
-RoxygenNote: 7.2.3
+RoxygenNote: 7.3.2

--- a/R/reactable-server.R
+++ b/R/reactable-server.R
@@ -178,7 +178,7 @@ get_data_on_page <- function(data, page_number, total_pages) {
     dplyr::select(!dplyr::any_of("reactable_data_page"))
 }
 
-#' Create reactable UI with server-side processing
+#' [Deprecated] Create reactable UI with server-side processing
 #'
 #' @param id element id
 #' @param width,height CSS unit (`"100%"`, `"400px"`, or `"auto"`), numeric for number of pixels
@@ -219,6 +219,11 @@ get_data_on_page <- function(data, page_number, total_pages) {
 #'   )
 #' }
 reactable_extras_ui <- function(id, width = "auto", height = "auto") {
+  .Deprecated(
+    new = "reactable::reactable",
+    msg = "`reactable::reactable` now has a `server = TRUE` argument. Please use 'reactable' directly instead of this module."
+  )
+
   checkmate::assert_character(id, len = 1)
 
   ns <- shiny::NS(id)

--- a/R/reactable-server.R
+++ b/R/reactable-server.R
@@ -178,7 +178,7 @@ get_data_on_page <- function(data, page_number, total_pages) {
     dplyr::select(!dplyr::any_of("reactable_data_page"))
 }
 
-#' [Deprecated] Create reactable UI with server-side processing
+#' (Deprecated) Create reactable UI with server-side processing
 #'
 #' @param id element id
 #' @param width,height CSS unit (`"100%"`, `"400px"`, or `"auto"`), numeric for number of pixels

--- a/R/reactable-server.R
+++ b/R/reactable-server.R
@@ -221,7 +221,8 @@ get_data_on_page <- function(data, page_number, total_pages) {
 reactable_extras_ui <- function(id, width = "auto", height = "auto") {
   .Deprecated(
     new = "reactable::reactable",
-    msg = "`reactable::reactable` now has a `server = TRUE` argument. Please use 'reactable' directly instead of this module."
+    msg = "`reactable::reactable` now has a `server = TRUE` argument.
+    Please use 'reactable' directly instead of this module."
   )
 
   checkmate::assert_character(id, len = 1)

--- a/man/reactable-extras-server.Rd
+++ b/man/reactable-extras-server.Rd
@@ -4,7 +4,7 @@
 \alias{reactable-extras-server}
 \alias{reactable_extras_ui}
 \alias{reactable_extras_server}
-\title{Create reactable UI with server-side processing}
+\title{\link{Deprecated} Create reactable UI with server-side processing}
 \usage{
 reactable_extras_ui(id, width = "auto", height = "auto")
 
@@ -27,7 +27,7 @@ reactable_extras_server(id, data, total_pages = 4, sortable = TRUE, ...)
 \code{reactable_extras_ui()} returns a custom UI for a server-side processed reactable
 }
 \description{
-Create reactable UI with server-side processing
+\link{Deprecated} Create reactable UI with server-side processing
 }
 \details{
 Arguments passed to \code{\link[reactable:reactable]{reactable::reactable()}} must not contain \code{pagination} or \code{showPagination}.

--- a/man/reactable-extras-server.Rd
+++ b/man/reactable-extras-server.Rd
@@ -4,7 +4,7 @@
 \alias{reactable-extras-server}
 \alias{reactable_extras_ui}
 \alias{reactable_extras_server}
-\title{\link{Deprecated} Create reactable UI with server-side processing}
+\title{(Deprecated) Create reactable UI with server-side processing}
 \usage{
 reactable_extras_ui(id, width = "auto", height = "auto")
 
@@ -27,7 +27,7 @@ reactable_extras_server(id, data, total_pages = 4, sortable = TRUE, ...)
 \code{reactable_extras_ui()} returns a custom UI for a server-side processed reactable
 }
 \description{
-\link{Deprecated} Create reactable UI with server-side processing
+(Deprecated) Create reactable UI with server-side processing
 }
 \details{
 Arguments passed to \code{\link[reactable:reactable]{reactable::reactable()}} must not contain \code{pagination} or \code{showPagination}.

--- a/reactable.extras.Rproj
+++ b/reactable.extras.Rproj
@@ -1,4 +1,5 @@
 Version: 1.0
+ProjectId: c1cefcba-92d9-4a94-9553-36fbb0131b66
 
 RestoreWorkspace: Default
 SaveWorkspace: Default

--- a/tests/testthat/_snaps/reactable-server.md
+++ b/tests/testthat/_snaps/reactable-server.md
@@ -29,6 +29,10 @@
 
     Code
       reactable_extras_ui("test")
+    Condition
+      Warning in `reactable_extras_ui()`:
+      `reactable::reactable` now has a `server = TRUE` argument.
+          Please use 'reactable' directly instead of this module.
     Output
       <div class="pagination-controls">
         <button class="btn btn-default action-button pagination-button" id="test-page_controls-first_page" type="button">

--- a/vignettes/tutorial/server-side-processing.rmd
+++ b/vignettes/tutorial/server-side-processing.rmd
@@ -11,6 +11,10 @@ Rendering a `reactable` with a lot of data can be inefficient. The initial loadi
 
 A more efficient approach is to render only the data that is needed to be displayed.
 
+<p class="alert alert-warning">
+The module `reactable_extras_ui`/`reactable_extras_server` is deprecated. We now recommend using the newest version of `reactable`, where the function `reactable::reactable` has an argument called `server` to enable server-side processing when set to `TRUE`. You can check the docs [here](https://glin.github.io/reactable/reference/reactable.html) and a detailed discussion [here](https://github.com/glin/reactable/issues/22#issuecomment-1475649659).
+</p>
+
 `reactable_extras_ui()` and `reactable_extras_server()` is a wrapper for `reactable::reactableOutput()` and `reactable::renderReactable({reactable(...)})`. It renders only a subset of a large data in the server memory. This almost instantly renders the desired page and keeps the amount of memory used in the browser minimal.
 
 Consider this example data:

--- a/vignettes/tutorial/server-side-processing.rmd
+++ b/vignettes/tutorial/server-side-processing.rmd
@@ -11,7 +11,7 @@ Rendering a `reactable` with a lot of data can be inefficient. The initial loadi
 
 A more efficient approach is to render only the data that is needed to be displayed.
 
-`reactable_extras_ui()` and `reactalbe_extras_server()` is a wrapper for `reactable::reactableOutput()` and `reactable::renderReactable({reactable(...)})`. It renders only a subset of a large data in the server memory. This almost instantly renders the desired page and keeps the amount of memory used in the browser minimal.
+`reactable_extras_ui()` and `reactable_extras_server()` is a wrapper for `reactable::reactableOutput()` and `reactable::renderReactable({reactable(...)})`. It renders only a subset of a large data in the server memory. This almost instantly renders the desired page and keeps the amount of memory used in the browser minimal.
 
 Consider this example data:
 


### PR DESCRIPTION
This PR just updates the docs pointing to the new reactable version, where there is a native server-side processing option for a reactable. This will let us arquive/mark-as-solved any issues related to this module.

## Description
Updated the server-side processing vignette with a warning
![image](https://github.com/user-attachments/assets/8ed05063-cbc2-46f5-b50c-d06f71c6fc99)

Added a
```
.Deprecated(
    new = "reactable::reactable",
    msg = "`reactable::reactable` now has a `server = TRUE` argument. Please use 'reactable' directly instead of this module."
  )
```
in reactable_extras_ui and changed its description to #' [Deprecated] Create reactable UI with server-side processing.

Definition of Done

- [X]  The change is thoroughly documented.
- [X]  The CI passes (R CMD check, linter, unit tests, spelling).
- [X]  Any generated files have been updated (e.g. .Rd files with roxygen2::roxygenise())